### PR TITLE
Catch error for certain type of scan

### DIFF
--- a/worker_srv.py
+++ b/worker_srv.py
@@ -60,10 +60,15 @@ class ScanProcessor():
                                              md['year'],
                                              md['cycle'],
                                              md['PROPOSAL'])
-        current_filepath = Path(current_path) / Path(md['name'])
-        current_filepath = ScanProcessor.get_new_filepath(str(current_filepath) + '.hdf5')
-        current_uid = md['uid']
-        self.gen_parser.load(current_uid)
+        try:
+            current_filepath = Path(current_path) / Path(md['name'])
+            current_filepath = ScanProcessor.get_new_filepath(str(current_filepath) + '.hdf5')
+            current_uid = md['uid']
+            self.gen_parser.load(current_uid)
+        except:
+            print("md['name'] not set")
+            pass
+        
 
         print('on the way')
         if 'plan_name' in md:


### PR DESCRIPTION
When ISS Xlive executes an alignment scan (one/multiple detectors vs one motor) the file name for the "interpolated" scan is not  set, so that the remote zeromq "worker"  was crashing.  Once 40 (20 threads on 2 servers) had crashed then all processing would stop.  

This is a mitigation to stop that for now.